### PR TITLE
Add 1plat.cash payment integration

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -92,7 +92,7 @@ export default {
       const good = GOODS.find(g => g.id === tid);
       if (!good) return new Response('Bad ID', {status:400});
 
-      const invoice = await createInvoice(good);   // пока заглушка
+      const invoice = await createInvoice(good, env);
       return html(`
         <h2>Оплата — ${escape(good.name)}</h2>
         <p>Переведите <b>${good.price} ₽</b> на реквизиты:</p>
@@ -116,7 +116,7 @@ export default {
       const good = GOODS.find(g => g.id === tid);
       if (!good) return new Response('bad', {status:400});
 
-      const paid = await isPaid(inv);              // сейчас всегда true
+      const paid = await isPaid(inv, env);
       if (!paid)
         return html("<p>Платёж ещё не подтверждён.</p><a href=\"/shop\">← Назад</a>");
 


### PR DESCRIPTION
## Summary
- integrate merchant order API in `createInvoice` and `isPaid`
- store guid in `PAYMENTS_KV`
- update worker to pass env to payment helpers

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d96bdd78083239e3dbb7f6a51d59a