### PR TITLE
Update payment env parameters

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -92,6 +92,7 @@ export default {
       const good = GOODS.find(g => g.id === tid);
       if (!good) return new Response('Bad ID', {status:400});
 
+      // env передаем вторым параметром согласно новому API
       const invoice = await createInvoice(good, env);
       return html(`
         <h2>Оплата — ${escape(good.name)}</h2>
@@ -116,6 +117,7 @@ export default {
       const good = GOODS.find(g => g.id === tid);
       if (!good) return new Response('bad', {status:400});
 
+      // env передаем вторым параметром согласно новому API
       const paid = await isPaid(inv, env);
       if (!paid)
         return html("<p>Платёж ещё не подтверждён.</p><a href=\"/shop\">← Назад</a>");

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,12 @@
+name = "websitemarket"
+compatibility_date = "2024-10-01"
+
+[vars]
+ONE_PLAT_KEY = ""
+ONE_PLAT_SECRET = ""
+SHOP_ID = ""
+
+[[kv_namespaces]]
+binding = "PAYMENTS_KV"
+id = ""
+preview_id = ""


### PR DESCRIPTION
## Summary
- ensure createInvoice and isPaid use `env` as the second parameter
- document payment env variables in `wrangler.toml`

## Testing
- `node -e "import('./payments.js').then(async m => { const env={PAYMENTS_USER_ID:1,PAYMENTS_KV:{put:async()=>{},get:async()=>''}}; const r = await m.createInvoice({price:100}, env); console.log(r); })"`
- `node -e "import('./payments.js').then(async m => { const ok = await m.isPaid('dummy', {PAYMENTS_KV:{get:async()=> '123456' }}); console.log(ok); })"`


------
https://chatgpt.com/codex/tasks/task_e_686d9a3080188323985a56601a320dbb